### PR TITLE
Add armenian rules

### DIFF
--- a/pygmatic_segmenter/languages/Armenian.py
+++ b/pygmatic_segmenter/languages/Armenian.py
@@ -1,0 +1,5 @@
+from pygmatic_segmenter.languages.Common import *
+
+PUNCTUATIONS = ['։', ':']
+
+SENTENCE_BOUNDARY_REGEX = r'.*?[։:]'

--- a/pygmatic_segmenter/languages/__init__.py
+++ b/pygmatic_segmenter/languages/__init__.py
@@ -1,8 +1,10 @@
 from pygmatic_segmenter.languages import English
 from pygmatic_segmenter.languages import Common
+from pygmatic_segmenter.languages import Armenian
 
 LANGUAGE_CODES = {
-	"en": English
+	"en": English,
+    "hy": Armenian
 }
 
 def get_language_by_code(code):

--- a/pygmatic_segmenter/languages/__init__.py
+++ b/pygmatic_segmenter/languages/__init__.py
@@ -3,7 +3,7 @@ from pygmatic_segmenter.languages import Common
 from pygmatic_segmenter.languages import Armenian
 
 LANGUAGE_CODES = {
-	"en": English,
+    "en": English,
     "hy": Armenian
 }
 


### PR DESCRIPTION
A contributor from Mozilla's Common Voice team redirected me to this project to segment sentences in python.  I figured adding a baseline implementation of armenian rules.  There are corner cases to address in which there might be a colon ":" in the middle of a sentence, splitting incorrectly.  For instance, here's a to-do -- handle time notations, i.e. Ես պետք է Օպերա գնամ ժամը 3:30:   

This baseline code works well most of the time, hence the motivation for the pull request.  

<img width="779" alt="Screen Shot 2021-04-07 at 4 00 26 PM" src="https://user-images.githubusercontent.com/33647474/113926674-7b1ad780-97ba-11eb-83a6-21198b03a4ce.png">
